### PR TITLE
Reset direction when starting a new game

### DIFF
--- a/src/se/kth/inda17/Game.java
+++ b/src/se/kth/inda17/Game.java
@@ -91,6 +91,8 @@ public class Game extends Application {
     }
 
     private void startBoxBallGame(Stage stage) {
+        userDirection = Direction.NONE;
+
         stage.hide();
         Group root = new Group();
         Scene scene = new Scene(root);


### PR DESCRIPTION
When starting a new game, reset the direction field `userDirection` by setting it to `Direction.NONE`.